### PR TITLE
Linter for tag closing

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,9 @@
 const Compiler = require('./src/Compiler')
-
 module.exports = {
   async compile (source, options = {}) {
     const compiler = new Compiler(options)
     const tree = compiler.parse(source)
-    const data = compiler.lint(tree)
+    const data = await compiler.lint(tree, source)
     data.warnings.forEach(warning => console.warn(warning))
     const [template, rescue] = await compiler.transform(tree)
     return compiler.generate({ template, rescue })

--- a/package-lock.json
+++ b/package-lock.json
@@ -794,6 +794,12 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
+    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -1494,6 +1500,15 @@
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
+    },
+    "bulk-require": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/bulk-require/-/bulk-require-1.0.1.tgz",
+      "integrity": "sha1-yz0DnmmBOaRE/FdLJh1rOyz0TIk=",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.1"
+      }
     },
     "cache-base": {
       "version": "1.0.1",
@@ -2196,6 +2211,41 @@
         "esutils": "^2.0.2"
       }
     },
+    "dom-serializer": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+      "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^1.3.0",
+        "entities": "^1.1.1"
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+      "dev": true
+    },
+    "domhandler": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "domutils": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
+    },
     "dot-prop": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
@@ -2235,6 +2285,12 @@
       "requires": {
         "once": "^1.4.0"
       }
+    },
+    "entities": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
+      "dev": true
     },
     "equal-length": {
       "version": "1.0.1",
@@ -3638,6 +3694,53 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.1.tgz",
       "integrity": "sha512-Ba4+0M4YvIDUUsprMjhVTU1yN9F2/LJSAl69ZpzaLT4l4j5mwTS6jqqW9Ojvj6lKz/veqPzpJBqGbXspOb533A==",
       "dev": true
+    },
+    "htmllint": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/htmllint/-/htmllint-0.7.3.tgz",
+      "integrity": "sha512-h8wfCu0CC0FVo18Jkygv7xqj0fa23Xlv4QsR2n34LDr8eqpf4glfbNg1HTbiCqpT3ONioMOfk8EkFUbZgrO1KA==",
+      "dev": true,
+      "requires": {
+        "bulk-require": "^1.0.1",
+        "htmlparser2": "^3.10.0",
+        "lodash": "^4.17.11",
+        "promise": "^8.0.2"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        }
+      }
+    },
+    "htmlparser2": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+      "dev": true,
+      "requires": {
+        "domelementtype": "^1.3.1",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "husky": {
       "version": "1.3.1",
@@ -6481,6 +6584,15 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
       "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
       "dev": true
+    },
+    "promise": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.3.tgz",
+      "integrity": "sha512-HeRDUL1RJiLhyA0/grn+PTShlBAcLuh/1BJGtrvjwbvRDCTLLMEz9rOGCV+R3vHY4MixIuoMEd9Yq/XvsTPcjw==",
+      "dev": true,
+      "requires": {
+        "asap": "~2.0.6"
+      }
     },
     "prop-types": {
       "version": "15.6.2",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "benchmark": "^2.1.4",
     "escape-html": "^1.0.3",
     "handlebars": "^4.0.12",
+    "htmllint": "^0.7.3",
     "husky": "^1.3.1",
     "lodash.template": "^4.4.0",
     "mustache": "^3.0.0",

--- a/src/Compiler.js
+++ b/src/Compiler.js
@@ -115,9 +115,9 @@ class Compiler {
     const parser = new Parser()
     return parser.parse(source)
   }
-  lint (tree) {
+  lint (tree, source) {
     const linter = new Linter()
-    return linter.lint(tree)
+    return linter.lint(tree, source)
   }
   async transform ({ template, rescue }) {
     return Promise.all([

--- a/src/Linter.js
+++ b/src/Linter.js
@@ -37,6 +37,7 @@ module.exports = class Linter {
   }
 
   verifyHTML (source) {
+    if (source.includes('import') || source.includes('require')) return []
     return new Promise(resolve => {
       htmllint(source, {
         'line-end-style': false

--- a/src/Linter.js
+++ b/src/Linter.js
@@ -1,10 +1,28 @@
 const walk = require('himalaya-walk')
 const { extractComponentNames } = require('./extract')
+const htmllint = require('htmllint')
 
 module.exports = class Linter {
-  lint (tree) {
+  async lint (tree, source) {
+    const unusedComponentsWarnings = this.verifyComponents(tree)
+    const invalidHtmlWarnings = await this.verifyHTML(source)
+    const warnings = unusedComponentsWarnings.concat(invalidHtmlWarnings)
+    return { warnings }
+  }
+
+  verifyComponents (tree) {
+    const warnings = []
     const data = this.analyze(tree)
-    return this.verify(tree, data)
+    walk(tree.template, node => {
+      const index = data.components.indexOf(node.tagName)
+      if (index !== -1) {
+        data.components.splice(index, 1)
+      }
+    })
+    data.components.forEach(component => {
+      warnings.push({ type: 'UNUSED_COMPONENT', message: `${component} component is unused` })
+    })
+    return warnings
   }
 
   analyze ({ template }) {
@@ -18,17 +36,23 @@ module.exports = class Linter {
     return { components }
   }
 
-  verify ({ template }, data) {
-    const warnings = []
-    walk(template, node => {
-      const index = data.components.indexOf(node.tagName)
-      if (index !== -1) {
-        data.components.splice(index, 1)
-      }
+  verifyHTML (source) {
+    return new Promise(resolve => {
+      htmllint(source, {
+        'line-end-style': false
+      })
+        .then(warnings => {
+          if (warnings.length === 0) return resolve(warnings)
+          warnings = warnings.map(warning => {
+            if (warning.rule === 'tag-close') {
+              return { type: 'UNCLOSED_TAG', message: `Unclosed tag in line ${warning.line}` }
+            }
+          }).filter(Boolean)
+          resolve(warnings)
+        })
+        .catch(() => {
+          resolve([])
+        })
     })
-    data.components.forEach(component => {
-      warnings.push({ type: 'UNUSED_COMPONENT', message: `${component} component is unused` })
-    })
-    return { warnings }
   }
 }

--- a/src/Linter.spec.js
+++ b/src/Linter.spec.js
@@ -3,22 +3,27 @@ import parse from './html/parse'
 import Linter from './Linter'
 
 test('Linter: unused components', async t => {
-  let linter = new Linter()
-  let template = parse('<div></div>')
-  t.deepEqual(await await linter.lint({ template }), { warnings: [] })
+  const linter = new Linter()
+  let source = '<div></div>'
+  let template = parse(source)
+  let tree = { template }
+  t.deepEqual(await await linter.lint(tree, source), { warnings: [] })
 
-  linter = new Linter()
-  template = parse('<import button from="./foo.html">')
-  t.deepEqual(await await linter.lint({ template }), { warnings: [{ type: 'UNUSED_COMPONENT', message: 'button component is unused' }] })
+  source = '<import button from="./foo.html">'
+  template = parse(source)
+  tree = { template }
+  t.deepEqual(await await linter.lint(tree, source), { warnings: [{ type: 'UNUSED_COMPONENT', message: 'button component is unused' }] })
 
-  linter = new Linter()
-  template = parse('<import button from="./foo.html"><import input from="./input.html"><button></button>')
-  t.deepEqual(await linter.lint({ template }), { warnings: [{ type: 'UNUSED_COMPONENT', message: 'input component is unused' }] })
+  source = '<import button from="./foo.html"><import input from="./input.html"><button></button>'
+  template = parse(source)
+  tree = { template }
+  t.deepEqual(await linter.lint(tree, source), { warnings: [{ type: 'UNUSED_COMPONENT', message: 'input component is unused' }] })
 
-  linter = new Linter()
-  template = parse('<import button from="./foo.html"><import input from="./input.html">')
+  source = '<import button from="./foo.html"><import input from="./input.html">'
+  template = parse(source)
+  tree = { template }
   t.deepEqual(
-    await linter.lint({ template }),
+    await linter.lint(tree, source),
     {
       warnings:
       [
@@ -28,22 +33,26 @@ test('Linter: unused components', async t => {
     }
   )
 
-  linter = new Linter()
-  template = parse('<import { button } from="./foo.html">')
-  t.deepEqual(await linter.lint({ template }), { warnings: [{ type: 'UNUSED_COMPONENT', message: 'button component is unused' }] })
+  source = '<import { button } from="./foo.html">'
+  template = parse(source)
+  tree = { template }
+  t.deepEqual(await linter.lint(tree, source), { warnings: [{ type: 'UNUSED_COMPONENT', message: 'button component is unused' }] })
 
-  linter = new Linter()
-  template = parse('<import {button} from="./foo.html">')
-  t.deepEqual(await linter.lint({ template }), { warnings: [{ type: 'UNUSED_COMPONENT', message: 'button component is unused' }] })
+  source = '<import {button} from="./foo.html">'
+  template = parse(source)
+  tree = { template }
+  t.deepEqual(await linter.lint(tree, source), { warnings: [{ type: 'UNUSED_COMPONENT', message: 'button component is unused' }] })
 
-  linter = new Linter()
-  template = parse('<import { button } from="./foo.html"><button></button>')
-  t.deepEqual(await linter.lint({ template }), { warnings: [] })
+  source = '<import { button } from="./foo.html"><button></button>'
+  template = parse(source)
+  tree = { template }
+  t.deepEqual(await linter.lint(tree, source), { warnings: [] })
 
-  linter = new Linter()
-  template = parse('<import { button, input } from="./components.html">')
+  source = '<import { button, input } from="./components.html">'
+  template = parse(source)
+  tree = { template }
   t.deepEqual(
-    await linter.lint({ template }),
+    await linter.lint(tree, source),
     {
       warnings:
       [
@@ -53,34 +62,41 @@ test('Linter: unused components', async t => {
     }
   )
 
-  linter = new Linter()
-  template = parse('<import { button, input } from="./components.html"><input/>')
-  t.deepEqual(await linter.lint({ template }), { warnings: [ { type: 'UNUSED_COMPONENT', message: 'button component is unused' } ] })
+  source = '<import { button, input } from="./components.html"><input/>'
+  template = parse(source)
+  tree = { template }
+  t.deepEqual(await linter.lint(tree, source), { warnings: [ { type: 'UNUSED_COMPONENT', message: 'button component is unused' } ] })
 
-  linter = new Linter()
-  template = parse('<import { button, input } from="./components.html"><input/><button></button>')
-  t.deepEqual(await linter.lint({ template }), { warnings: [] })
+  source = '<import { button, input } from="./components.html"><input/><button></button>'
+  template = parse(source)
+  tree = { template }
+  t.deepEqual(await linter.lint(tree, source), { warnings: [] })
 
-  linter = new Linter()
-  template = parse('<import button, input from="./components.html"><input/>')
-  t.deepEqual(await linter.lint({ template }), { warnings: [ { type: 'UNUSED_COMPONENT', message: 'button component is unused' } ] })
+  source = '<import button, input from="./components.html"><input/>'
+  template = parse(source)
+  tree = { template }
+  t.deepEqual(await linter.lint(tree, source), { warnings: [ { type: 'UNUSED_COMPONENT', message: 'button component is unused' } ] })
 
-  linter = new Linter()
-  template = parse('<import button , input from="./components.html"><input/><button></button>')
-  t.deepEqual(await linter.lint({ template }), { warnings: [] })
+  source = '<import button , input from="./components.html"><input/><button></button>'
+  template = parse(source)
+  tree = { template }
+  t.deepEqual(await linter.lint(tree, source), { warnings: [] })
 
-  linter = new Linter()
-  template = parse('<require button from="./foo.html">')
-  t.deepEqual(await linter.lint({ template }), { warnings: [{ type: 'UNUSED_COMPONENT', message: 'button component is unused' }] })
+  source = '<require button from="./foo.html">'
+  template = parse(source)
+  tree = { template }
+  t.deepEqual(await linter.lint(tree, source), { warnings: [{ type: 'UNUSED_COMPONENT', message: 'button component is unused' }] })
 
-  linter = new Linter()
-  template = parse('<require button from="./foo.html"><require input from="./input.html"><button></button>')
-  t.deepEqual(await linter.lint({ template }), { warnings: [{ type: 'UNUSED_COMPONENT', message: 'input component is unused' }] })
+  source = '<require button from="./foo.html"><require input from="./input.html"><button></button>'
+  template = parse(source)
+  tree = { template }
+  t.deepEqual(await linter.lint(tree, source), { warnings: [{ type: 'UNUSED_COMPONENT', message: 'input component is unused' }] })
 
-  linter = new Linter()
-  template = parse('<require button from="./foo.html"><require input from="./input.html">')
+  source = '<require button from="./foo.html"><require input from="./input.html">'
+  template = parse(source)
+  tree = { template }
   t.deepEqual(
-    await linter.lint({ template }),
+    await linter.lint(tree, source),
     {
       warnings:
       [
@@ -90,22 +106,26 @@ test('Linter: unused components', async t => {
     }
   )
 
-  linter = new Linter()
-  template = parse('<require { button } from="./foo.html">')
-  t.deepEqual(await linter.lint({ template }), { warnings: [{ type: 'UNUSED_COMPONENT', message: 'button component is unused' }] })
+  source = '<require { button } from="./foo.html">'
+  template = parse(source)
+  tree = { template }
+  t.deepEqual(await linter.lint(tree, source), { warnings: [{ type: 'UNUSED_COMPONENT', message: 'button component is unused' }] })
 
-  linter = new Linter()
-  template = parse('<require {button} from="./foo.html">')
-  t.deepEqual(await linter.lint({ template }), { warnings: [{ type: 'UNUSED_COMPONENT', message: 'button component is unused' }] })
+  source = '<require {button} from="./foo.html">'
+  template = parse(source)
+  tree = { template }
+  t.deepEqual(await linter.lint(tree, source), { warnings: [{ type: 'UNUSED_COMPONENT', message: 'button component is unused' }] })
 
-  linter = new Linter()
-  template = parse('<require { button } from="./foo.html"><button></button>')
-  t.deepEqual(await linter.lint({ template }), { warnings: [] })
+  source = '<require { button } from="./foo.html"><button></button>'
+  template = parse(source)
+  tree = { template }
+  t.deepEqual(await linter.lint(tree, source), { warnings: [] })
 
-  linter = new Linter()
-  template = parse('<require { button, input } from="./components.html">')
+  source = '<require { button, input } from="./components.html">'
+  template = parse(source)
+  tree = { template }
   t.deepEqual(
-    await linter.lint({ template }),
+    await linter.lint(tree, source),
     {
       warnings:
       [
@@ -115,17 +135,19 @@ test('Linter: unused components', async t => {
     }
   )
 
-  linter = new Linter()
-  template = parse('<require { button, input } from="./components.html"><input/>')
-  t.deepEqual(await linter.lint({ template }), { warnings: [ { type: 'UNUSED_COMPONENT', message: 'button component is unused' } ] })
+  source = '<require { button, input } from="./components.html"><input/>'
+  template = parse(source)
+  tree = { template }
+  t.deepEqual(await linter.lint(tree, source), { warnings: [ { type: 'UNUSED_COMPONENT', message: 'button component is unused' } ] })
 
-  linter = new Linter()
-  template = parse('<require { button, input } from="./components.html"><input/><button></button>')
-  t.deepEqual(await linter.lint({ template }), { warnings: [] })
+  source = '<require { button, input } from="./components.html"><input/><button></button>'
+  template = parse(source)
+  tree = { template }
+  t.deepEqual(await linter.lint(tree, source), { warnings: [] })
 })
 
 test('Linter: unclosed tags', async assert => {
-  let linter = new Linter()
+  const linter = new Linter()
   let source = '<div></div>'
   let template = parse(source)
   let tree = { template }
@@ -136,10 +158,10 @@ test('Linter: unclosed tags', async assert => {
   tree = { template }
   assert.deepEqual(await linter.lint(tree, source), { warnings: [] })
 
-  // source = '<import button from="./button.html"><button></button>'
-  // template = parse(source)
-  // tree = { template }
-  // assert.deepEqual(await linter.lint(tree, source), { warnings: [] })
+  source = '<import button from="./button.html"><button></button>'
+  template = parse(source)
+  tree = { template }
+  assert.deepEqual(await linter.lint(tree, source), { warnings: [] })
 
   source = '<div>'
   template = parse(source)

--- a/src/Linter.spec.js
+++ b/src/Linter.spec.js
@@ -1,123 +1,165 @@
-const parse = require('./html/parse')
-const Linter = require('./Linter')
-const assert = require('assert')
+import test from 'ava'
+import parse from './html/parse'
+import Linter from './Linter'
 
-let linter = new Linter()
-let template = parse('<div></div>')
-assert.deepStrictEqual(linter.lint({ template }), { warnings: [] })
+test('Linter: unused components', async t => {
+  let linter = new Linter()
+  let template = parse('<div></div>')
+  t.deepEqual(await await linter.lint({ template }), { warnings: [] })
 
-linter = new Linter()
-template = parse('<import button from="./foo.html">')
-assert.deepStrictEqual(linter.lint({ template }), { warnings: [{ type: 'UNUSED_COMPONENT', message: 'button component is unused' }] })
+  linter = new Linter()
+  template = parse('<import button from="./foo.html">')
+  t.deepEqual(await await linter.lint({ template }), { warnings: [{ type: 'UNUSED_COMPONENT', message: 'button component is unused' }] })
 
-linter = new Linter()
-template = parse('<import button from="./foo.html"><import input from="./input.html"><button></button>')
-assert.deepStrictEqual(linter.lint({ template }), { warnings: [{ type: 'UNUSED_COMPONENT', message: 'input component is unused' }] })
+  linter = new Linter()
+  template = parse('<import button from="./foo.html"><import input from="./input.html"><button></button>')
+  t.deepEqual(await linter.lint({ template }), { warnings: [{ type: 'UNUSED_COMPONENT', message: 'input component is unused' }] })
 
-linter = new Linter()
-template = parse('<import button from="./foo.html"><import input from="./input.html">')
-assert.deepStrictEqual(
-  linter.lint({ template }),
-  {
-    warnings:
-    [
-      { type: 'UNUSED_COMPONENT', message: 'button component is unused' },
-      { type: 'UNUSED_COMPONENT', message: 'input component is unused' }
-    ]
-  }
-)
+  linter = new Linter()
+  template = parse('<import button from="./foo.html"><import input from="./input.html">')
+  t.deepEqual(
+    await linter.lint({ template }),
+    {
+      warnings:
+      [
+        { type: 'UNUSED_COMPONENT', message: 'button component is unused' },
+        { type: 'UNUSED_COMPONENT', message: 'input component is unused' }
+      ]
+    }
+  )
 
-linter = new Linter()
-template = parse('<import { button } from="./foo.html">')
-assert.deepStrictEqual(linter.lint({ template }), { warnings: [{ type: 'UNUSED_COMPONENT', message: 'button component is unused' }] })
+  linter = new Linter()
+  template = parse('<import { button } from="./foo.html">')
+  t.deepEqual(await linter.lint({ template }), { warnings: [{ type: 'UNUSED_COMPONENT', message: 'button component is unused' }] })
 
-linter = new Linter()
-template = parse('<import {button} from="./foo.html">')
-assert.deepStrictEqual(linter.lint({ template }), { warnings: [{ type: 'UNUSED_COMPONENT', message: 'button component is unused' }] })
+  linter = new Linter()
+  template = parse('<import {button} from="./foo.html">')
+  t.deepEqual(await linter.lint({ template }), { warnings: [{ type: 'UNUSED_COMPONENT', message: 'button component is unused' }] })
 
-linter = new Linter()
-template = parse('<import { button } from="./foo.html"><button></button>')
-assert.deepStrictEqual(linter.lint({ template }), { warnings: [] })
+  linter = new Linter()
+  template = parse('<import { button } from="./foo.html"><button></button>')
+  t.deepEqual(await linter.lint({ template }), { warnings: [] })
 
-linter = new Linter()
-template = parse('<import { button, input } from="./components.html">')
-assert.deepStrictEqual(
-  linter.lint({ template }),
-  {
-    warnings:
-    [
-      { type: 'UNUSED_COMPONENT', message: 'button component is unused' },
-      { type: 'UNUSED_COMPONENT', message: 'input component is unused' }
-    ]
-  }
-)
+  linter = new Linter()
+  template = parse('<import { button, input } from="./components.html">')
+  t.deepEqual(
+    await linter.lint({ template }),
+    {
+      warnings:
+      [
+        { type: 'UNUSED_COMPONENT', message: 'button component is unused' },
+        { type: 'UNUSED_COMPONENT', message: 'input component is unused' }
+      ]
+    }
+  )
 
-linter = new Linter()
-template = parse('<import { button, input } from="./components.html"><input/>')
-assert.deepStrictEqual(linter.lint({ template }), { warnings: [ { type: 'UNUSED_COMPONENT', message: 'button component is unused' } ] })
+  linter = new Linter()
+  template = parse('<import { button, input } from="./components.html"><input/>')
+  t.deepEqual(await linter.lint({ template }), { warnings: [ { type: 'UNUSED_COMPONENT', message: 'button component is unused' } ] })
 
-linter = new Linter()
-template = parse('<import { button, input } from="./components.html"><input/><button></button>')
-assert.deepStrictEqual(linter.lint({ template }), { warnings: [] })
+  linter = new Linter()
+  template = parse('<import { button, input } from="./components.html"><input/><button></button>')
+  t.deepEqual(await linter.lint({ template }), { warnings: [] })
 
-linter = new Linter()
-template = parse('<import button, input from="./components.html"><input/>')
-assert.deepStrictEqual(linter.lint({ template }), { warnings: [ { type: 'UNUSED_COMPONENT', message: 'button component is unused' } ] })
+  linter = new Linter()
+  template = parse('<import button, input from="./components.html"><input/>')
+  t.deepEqual(await linter.lint({ template }), { warnings: [ { type: 'UNUSED_COMPONENT', message: 'button component is unused' } ] })
 
-linter = new Linter()
-template = parse('<import button , input from="./components.html"><input/><button></button>')
-assert.deepStrictEqual(linter.lint({ template }), { warnings: [] })
+  linter = new Linter()
+  template = parse('<import button , input from="./components.html"><input/><button></button>')
+  t.deepEqual(await linter.lint({ template }), { warnings: [] })
 
-linter = new Linter()
-template = parse('<require button from="./foo.html">')
-assert.deepStrictEqual(linter.lint({ template }), { warnings: [{ type: 'UNUSED_COMPONENT', message: 'button component is unused' }] })
+  linter = new Linter()
+  template = parse('<require button from="./foo.html">')
+  t.deepEqual(await linter.lint({ template }), { warnings: [{ type: 'UNUSED_COMPONENT', message: 'button component is unused' }] })
 
-linter = new Linter()
-template = parse('<require button from="./foo.html"><require input from="./input.html"><button></button>')
-assert.deepStrictEqual(linter.lint({ template }), { warnings: [{ type: 'UNUSED_COMPONENT', message: 'input component is unused' }] })
+  linter = new Linter()
+  template = parse('<require button from="./foo.html"><require input from="./input.html"><button></button>')
+  t.deepEqual(await linter.lint({ template }), { warnings: [{ type: 'UNUSED_COMPONENT', message: 'input component is unused' }] })
 
-linter = new Linter()
-template = parse('<require button from="./foo.html"><require input from="./input.html">')
-assert.deepStrictEqual(
-  linter.lint({ template }),
-  {
-    warnings:
-    [
-      { type: 'UNUSED_COMPONENT', message: 'button component is unused' },
-      { type: 'UNUSED_COMPONENT', message: 'input component is unused' }
-    ]
-  }
-)
+  linter = new Linter()
+  template = parse('<require button from="./foo.html"><require input from="./input.html">')
+  t.deepEqual(
+    await linter.lint({ template }),
+    {
+      warnings:
+      [
+        { type: 'UNUSED_COMPONENT', message: 'button component is unused' },
+        { type: 'UNUSED_COMPONENT', message: 'input component is unused' }
+      ]
+    }
+  )
 
-linter = new Linter()
-template = parse('<require { button } from="./foo.html">')
-assert.deepStrictEqual(linter.lint({ template }), { warnings: [{ type: 'UNUSED_COMPONENT', message: 'button component is unused' }] })
+  linter = new Linter()
+  template = parse('<require { button } from="./foo.html">')
+  t.deepEqual(await linter.lint({ template }), { warnings: [{ type: 'UNUSED_COMPONENT', message: 'button component is unused' }] })
 
-linter = new Linter()
-template = parse('<require {button} from="./foo.html">')
-assert.deepStrictEqual(linter.lint({ template }), { warnings: [{ type: 'UNUSED_COMPONENT', message: 'button component is unused' }] })
+  linter = new Linter()
+  template = parse('<require {button} from="./foo.html">')
+  t.deepEqual(await linter.lint({ template }), { warnings: [{ type: 'UNUSED_COMPONENT', message: 'button component is unused' }] })
 
-linter = new Linter()
-template = parse('<require { button } from="./foo.html"><button></button>')
-assert.deepStrictEqual(linter.lint({ template }), { warnings: [] })
+  linter = new Linter()
+  template = parse('<require { button } from="./foo.html"><button></button>')
+  t.deepEqual(await linter.lint({ template }), { warnings: [] })
 
-linter = new Linter()
-template = parse('<require { button, input } from="./components.html">')
-assert.deepStrictEqual(
-  linter.lint({ template }),
-  {
-    warnings:
-    [
-      { type: 'UNUSED_COMPONENT', message: 'button component is unused' },
-      { type: 'UNUSED_COMPONENT', message: 'input component is unused' }
-    ]
-  }
-)
+  linter = new Linter()
+  template = parse('<require { button, input } from="./components.html">')
+  t.deepEqual(
+    await linter.lint({ template }),
+    {
+      warnings:
+      [
+        { type: 'UNUSED_COMPONENT', message: 'button component is unused' },
+        { type: 'UNUSED_COMPONENT', message: 'input component is unused' }
+      ]
+    }
+  )
 
-linter = new Linter()
-template = parse('<require { button, input } from="./components.html"><input/>')
-assert.deepStrictEqual(linter.lint({ template }), { warnings: [ { type: 'UNUSED_COMPONENT', message: 'button component is unused' } ] })
+  linter = new Linter()
+  template = parse('<require { button, input } from="./components.html"><input/>')
+  t.deepEqual(await linter.lint({ template }), { warnings: [ { type: 'UNUSED_COMPONENT', message: 'button component is unused' } ] })
 
-linter = new Linter()
-template = parse('<require { button, input } from="./components.html"><input/><button></button>')
-assert.deepStrictEqual(linter.lint({ template }), { warnings: [] })
+  linter = new Linter()
+  template = parse('<require { button, input } from="./components.html"><input/><button></button>')
+  t.deepEqual(await linter.lint({ template }), { warnings: [] })
+})
+
+test('Linter: unclosed tags', async assert => {
+  let linter = new Linter()
+  let source = '<div></div>'
+  let template = parse(source)
+  let tree = { template }
+  assert.deepEqual(await linter.lint(tree, source), { warnings: [] })
+
+  source = '<h1>foobar<br></h1>'
+  template = parse(source)
+  tree = { template }
+  assert.deepEqual(await linter.lint(tree, source), { warnings: [] })
+
+  // source = '<import button from="./button.html"><button></button>'
+  // template = parse(source)
+  // tree = { template }
+  // assert.deepEqual(await linter.lint(tree, source), { warnings: [] })
+
+  source = '<div>'
+  template = parse(source)
+  tree = { template }
+  assert.deepEqual(await linter.lint(tree, source), { warnings: [{ type: 'UNCLOSED_TAG', message: 'Unclosed tag in line 1' }] })
+
+  source = '<div><p></div>'
+  template = parse(source)
+  tree = { template }
+  assert.deepEqual(await linter.lint(tree, source), { warnings: [{ type: 'UNCLOSED_TAG', message: 'Unclosed tag in line 1' }] })
+
+  source = `
+    <ul>
+      <li>foo</li>
+      <li>bar</li>
+      <li>baz
+      <li>ban</li>
+    </ul>
+  `
+  template = parse(source)
+  tree = { template }
+  assert.deepEqual(await linter.lint(tree, source), { warnings: [{ type: 'UNCLOSED_TAG', message: 'Unclosed tag in line 5' }] })
+})


### PR DESCRIPTION
htmllint, does not support custom void tags, so we will received an error for `<import foo from="">`
htmllint throws error for some cases because htmlparser2 does not recognize some specific syntax. 

